### PR TITLE
fix "synchro_log" table creation

### DIFF
--- a/ExtLibs/djson/Sources/DJSON.Engine.DOM.pas
+++ b/ExtLibs/djson/Sources/DJSON.Engine.DOM.pas
@@ -1300,7 +1300,7 @@ begin
   if LQualifiedTypeName = 'System.SysUtils.TTimeStamp' then
   begin
     ts := AValue.AsType<System.SysUtils.TTimeStamp>;
-    Result := TJSONNumber.Create(TimeStampToMsecs(ts));
+    Result := TJSONNumber.Create(CompToDouble(TimeStampToMsecs(ts)));
   end
   // TValue
   else if LQualifiedTypeName = 'System.Rtti.TValue' then

--- a/Source/iORM.SynchroStrategy.Custom.pas
+++ b/Source/iORM.SynchroStrategy.Custom.pas
@@ -90,7 +90,7 @@ type
     property CliToSrv_Count: Integer read FCliToSrv_Count write FCliToSrv_Count;
     property SrvToCli_Count: Integer read FSrvToCli_Count write FSrvToCli_Count;
     // Timing
-    property Start: TTime read FStartSynchro write FStartSynchro;
+    property StartSynchro: TTime read FStartSynchro write FStartSynchro;
     property LoadFromClient: TTime read FLoadFromClient write FLoadFromClient;
     property PersistToServer: TTime read FPersistToServer write FPersistToServer;
     property ReloadFromServer: TTime read FReloadFromServer write FReloadFromServer;
@@ -752,7 +752,7 @@ end;
 procedure TioCustomSynchroStrategy_Payload._DoNewSynchroLogItem_Initialize;
 begin
   // Initialize the new SynchroLogItem after its creation
-  FSynchroLogItem_New.Start := Now;
+  FSynchroLogItem_New.StartSynchro := Now;
   FSynchroLogItem_New.SynchroStatus := TioSynchroStatus.ssInitialization;
   FSynchroLogItem_New.SynchroLevel := FSynchroLevel;
   FSynchroLogItem_New.SynchroLogName := FSynchroLogName;


### PR DESCRIPTION
With "start" field name, firebird throw this exception

First chance exception at $77879A72. Exception class EIBNativeException with message '[FireDAC][Phys][FB]Dynamic SQL Error
SQL error code = -104
Token unknown - line 13, column 6
Start'.
Process keyserver.exe (27736)